### PR TITLE
Allow onAdd to be called with values

### DIFF
--- a/packages/theme-bootstrap4/src/renderers/inline-linked-struct-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/inline-linked-struct-field-renderer.tsx
@@ -44,7 +44,7 @@ const Bootstrap4InlineLinkedStructFieldRenderer = ({
           <Bootstrap4ButtonRenderer
             classes="btn btn-sm btn-secondary"
             text="Add"
-            onClick={onAdd}
+            onClick={() => onAdd()}
             disabled={disabled}
           />
         )}

--- a/packages/theme-bootstrap4/src/renderers/table-linked-struct-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/table-linked-struct-field-renderer.tsx
@@ -61,7 +61,7 @@ const Bootstrap4TableLinkedStructFieldRenderer = ({
           <Bootstrap4ButtonRenderer
             classes="btn btn-sm btn-secondary"
             text="Add"
-            onClick={onAdd}
+            onClick={() => onAdd()}
             disabled={disabled}
           />
         )}

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.actions.ts
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.actions.ts
@@ -278,6 +278,7 @@ export default function fieldHostRendererActions(store: IStore) {
       startingIndex: number,
       count: number = 1,
       navigateFunc?: (index: number) => void,
+      values?: object[],
     ): Partial<IStoreState> | Promise<Partial<IStoreState>> => {
       const linkedStructField = state.schema.fields
         .get(structName)
@@ -292,7 +293,12 @@ export default function fieldHostRendererActions(store: IStore) {
 
       if (type === 'add') {
         for (let i = 0; i < itemsToCreate; i++) {
-          const newValue = createFieldParent(state.schema, structName);
+          let newValue: object;
+          if (Array.isArray(values) && typeof values[i] === 'object') {
+            newValue = values[i];
+          } else {
+            newValue = createFieldParent(state.schema, structName);
+          }
 
           newPaths.push(`${fieldPath}.${startingIndex + i}`);
           newValues.push(newValue);

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.actions.ts
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.actions.ts
@@ -417,10 +417,10 @@ export default function fieldHostRendererActions(store: IStore) {
         }
 
         state.onFieldParentChange(params);
+      }
 
-        if (navigateFunc) {
-          navigateFunc(startingIndex);
-        }
+      if (navigateFunc) {
+        navigateFunc(startingIndex);
       }
 
       return {};

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -194,6 +194,7 @@ export default class FieldHostRenderer extends BaseComponent<
     index: number,
     count: number = 1,
     navigate: boolean = true,
+    values: object[] = undefined,
   ) => {
     const { struct, changeArrayValue, fieldReference, fieldPath } = this.props;
     const linkedStructFieldReference = fieldReference as ILinkedStructFieldReference;
@@ -208,6 +209,7 @@ export default class FieldHostRenderer extends BaseComponent<
       index,
       count,
       shouldNavigate ? this.navigate : null,
+      values,
     );
   };
 
@@ -464,7 +466,14 @@ export default class FieldHostRenderer extends BaseComponent<
               );
               return blockField.label.short;
             }),
-            onAdd: () => this.onAdd((mappedValue && mappedValue.length) || 0),
+            onAdd: (value: object = undefined, navigate: boolean = true) => {
+              this.onAdd(
+                (mappedValue && mappedValue.length) || 0,
+                1,
+                navigate,
+                [value],
+              );
+            },
             onEdit: this.onEdit,
             onRemove: this.onRemove,
             busyValues,

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -511,7 +511,9 @@ export default class FieldHostRenderer extends BaseComponent<
           ...fieldProps,
           canAdd: this.canAdd,
           canRemove: this.canRemove,
-          onAdd: () => this.onAdd((values && values.length) || 0),
+          onAdd: (value: object = undefined) => {
+            this.onAdd((values && values.length) || 0, 1, false, [value]);
+          },
           onRemove: this.onRemove,
           busyRenderedItems: busyValues,
           disabledRenderedItems: disabledValues,

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.props.ts
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.props.ts
@@ -61,6 +61,7 @@ export interface IFieldHostRendererProps
     startingIndex: number,
     count: number,
     navigateFunc?: (index: number) => void,
+    values?: object[],
   ) => void;
   push: (state: INavState) => void;
 }

--- a/packages/ui/src/renderers/index.ts
+++ b/packages/ui/src/renderers/index.ts
@@ -134,7 +134,7 @@ export interface ITableLinkedStructRenderer extends IFieldRenderer {
   disabledValues: { [index: number]: boolean };
   canAdd: () => boolean;
   canRemove: (index: number) => boolean;
-  onAdd: () => void;
+  onAdd: (value?: object, navigate?: boolean) => void;
   onEdit: (index: number) => void;
   onRemove: (index: number) => void;
 }
@@ -145,7 +145,7 @@ export interface IInlineLinkedStructRenderer extends IFieldRenderer {
   disabledRenderedItems: { [index: number]: boolean };
   canAdd: () => boolean;
   canRemove: (index: number) => boolean;
-  onAdd: () => void;
+  onAdd: (value?: object, navigate?: boolean) => void;
   onRemove: (index: number) => void;
 }
 

--- a/packages/ui/src/renderers/index.ts
+++ b/packages/ui/src/renderers/index.ts
@@ -145,7 +145,7 @@ export interface IInlineLinkedStructRenderer extends IFieldRenderer {
   disabledRenderedItems: { [index: number]: boolean };
   canAdd: () => boolean;
   canRemove: (index: number) => boolean;
-  onAdd: (value?: object, navigate?: boolean) => void;
+  onAdd: (value?: object) => void;
   onRemove: (index: number) => void;
 }
 


### PR DESCRIPTION
This allows custom renderers to control the navigation process as well as supply the value to be used when calling the `onAdd` callback.