### PR TITLE
Disable tabbing on read only fields

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.16.11"
+  "version": "0.16.12"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -5,5 +5,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.16.10"
+  "version": "0.16.11"
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@de-re-crud/angular",
   "description": "Angular wrapper for De Re CRUD",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/angular",
   "license": "Apache-2.0",
   "peerDependencies": {
     "@angular/cdk": "^8.0.0 || ^9.0.0",
     "@angular/common": "^8.0.0 || ^9.0.0",
     "@angular/core": "^8.0.0 || ^9.0.0",
-    "@de-re-crud/core": "0.16.10",
-    "@de-re-crud/ui": "0.16.10"
+    "@de-re-crud/core": "0.16.11",
+    "@de-re-crud/ui": "0.16.11"
   },
   "devDependencies": {
     "@angular/animations": "^9.0.1",
@@ -22,9 +22,9 @@
     "@angular/platform-browser": "^9.0.1",
     "@angular/platform-browser-dynamic": "^9.0.1",
     "@angular/router": "^9.0.1",
-    "@de-re-crud/core": "^0.16.10",
-    "@de-re-crud/theme-bootstrap4": "^0.16.10",
-    "@de-re-crud/ui": "^0.16.10",
+    "@de-re-crud/core": "^0.16.11",
+    "@de-re-crud/theme-bootstrap4": "^0.16.11",
+    "@de-re-crud/ui": "^0.16.11",
     "@testing-library/angular": "^8.2.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/angular",
   "description": "Angular wrapper for De Re CRUD",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/angular",
   "license": "Apache-2.0",
   "peerDependencies": {
@@ -22,9 +22,9 @@
     "@angular/platform-browser": "^9.0.1",
     "@angular/platform-browser-dynamic": "^9.0.1",
     "@angular/router": "^9.0.1",
-    "@de-re-crud/core": "^0.16.11",
-    "@de-re-crud/theme-bootstrap4": "^0.16.11",
-    "@de-re-crud/ui": "^0.16.11",
+    "@de-re-crud/core": "^0.16.12",
+    "@de-re-crud/theme-bootstrap4": "^0.16.12",
+    "@de-re-crud/ui": "^0.16.12",
     "@testing-library/angular": "^8.2.0",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/core",
   "description": "Core library for De Re CRUD",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/core",
   "license": "Apache-2.0",
   "main": "de-re-crud-core.umd.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/core",
   "description": "Core library for De Re CRUD",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/core",
   "license": "Apache-2.0",
   "main": "de-re-crud-core.umd.js",

--- a/packages/storybook-angular/package.json
+++ b/packages/storybook-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/storybook-angular",
   "private": true,
-  "version": "0.16.10",
+  "version": "0.16.11",
   "scripts": {
     "storybook": "start-storybook -p 9001",
     "build": "build-storybook -c .storybook -o dist"
@@ -18,10 +18,10 @@
     "@angular/platform-browser": "^9.0.1",
     "@angular/platform-browser-dynamic": "^9.0.1",
     "@babel/core": "^7.5.5",
-    "@de-re-crud/angular": "^0.16.10",
-    "@de-re-crud/core": "^0.16.10",
-    "@de-re-crud/theme-bootstrap4": "^0.16.10",
-    "@de-re-crud/ui": "^0.16.10",
+    "@de-re-crud/angular": "^0.16.11",
+    "@de-re-crud/core": "^0.16.11",
+    "@de-re-crud/theme-bootstrap4": "^0.16.11",
+    "@de-re-crud/ui": "^0.16.11",
     "@storybook/addon-actions": "5.3.13",
     "@storybook/angular": "^5.3.13",
     "awesome-typescript-loader": "^5.2.1",

--- a/packages/storybook-angular/package.json
+++ b/packages/storybook-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/storybook-angular",
   "private": true,
-  "version": "0.16.11",
+  "version": "0.16.12",
   "scripts": {
     "storybook": "start-storybook -p 9001",
     "build": "build-storybook -c .storybook -o dist"
@@ -18,10 +18,10 @@
     "@angular/platform-browser": "^9.0.1",
     "@angular/platform-browser-dynamic": "^9.0.1",
     "@babel/core": "^7.5.5",
-    "@de-re-crud/angular": "^0.16.11",
-    "@de-re-crud/core": "^0.16.11",
-    "@de-re-crud/theme-bootstrap4": "^0.16.11",
-    "@de-re-crud/ui": "^0.16.11",
+    "@de-re-crud/angular": "^0.16.12",
+    "@de-re-crud/core": "^0.16.12",
+    "@de-re-crud/theme-bootstrap4": "^0.16.12",
+    "@de-re-crud/ui": "^0.16.12",
     "@storybook/addon-actions": "5.3.13",
     "@storybook/angular": "^5.3.13",
     "awesome-typescript-loader": "^5.2.1",

--- a/packages/storybook-ui/package.json
+++ b/packages/storybook-ui/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@de-re-crud/storybook-ui",
   "private": true,
-  "version": "0.16.10",
+  "version": "0.16.11",
   "scripts": {
     "storybook": "start-storybook -p 9000",
     "build": "build-storybook -c .storybook -o dist"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",
-    "@de-re-crud/core": "^0.16.10",
-    "@de-re-crud/theme-bootstrap4": "^0.16.10",
-    "@de-re-crud/ui": "^0.16.10",
+    "@de-re-crud/core": "^0.16.11",
+    "@de-re-crud/theme-bootstrap4": "^0.16.11",
+    "@de-re-crud/ui": "^0.16.11",
     "@storybook/addon-actions": "5.3.13",
     "@storybook/preact": "^5.3.13",
     "awesome-typescript-loader": "^5.2.1",

--- a/packages/storybook-ui/package.json
+++ b/packages/storybook-ui/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@de-re-crud/storybook-ui",
   "private": true,
-  "version": "0.16.11",
+  "version": "0.16.12",
   "scripts": {
     "storybook": "start-storybook -p 9000",
     "build": "build-storybook -c .storybook -o dist"
   },
   "dependencies": {
     "@babel/core": "^7.5.5",
-    "@de-re-crud/core": "^0.16.11",
-    "@de-re-crud/theme-bootstrap4": "^0.16.11",
-    "@de-re-crud/ui": "^0.16.11",
+    "@de-re-crud/core": "^0.16.12",
+    "@de-re-crud/theme-bootstrap4": "^0.16.12",
+    "@de-re-crud/ui": "^0.16.12",
     "@storybook/addon-actions": "5.3.13",
     "@storybook/preact": "^5.3.13",
     "awesome-typescript-loader": "^5.2.1",

--- a/packages/storybook-ui/src/renderers/create-default-props.ts
+++ b/packages/storybook-ui/src/renderers/create-default-props.ts
@@ -18,6 +18,7 @@ export function createDefaultProps(
     busy: false,
     disabled: false,
     readOnly: false,
+    tabIndex: undefined,
     hints: {},
     onBlur: action('blur'),
     onFocus: action('focus'),

--- a/packages/storybook-ui/src/schema.json
+++ b/packages/storybook-ui/src/schema.json
@@ -19,8 +19,8 @@
           "name": "label",
           "label": "Label",
           "type": "text",
+          "required": true,
           "hints": {
-            "readOnly": true,
             "width": 8
           }
         },

--- a/packages/storybook-ui/src/schema.json
+++ b/packages/storybook-ui/src/schema.json
@@ -19,8 +19,8 @@
           "name": "label",
           "label": "Label",
           "type": "text",
-          "required": true,
           "hints": {
+            "readOnly": true,
             "width": 8
           }
         },

--- a/packages/theme-bootstrap4/package.json
+++ b/packages/theme-bootstrap4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/theme-bootstrap4",
   "description": "Bootstrap 4 theme for De Re CRUD interfaces",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/theme-bootstrap4",
   "license": "Apache-2.0",
   "main": "de-re-crud-theme-bootstrap4.umd.js",
@@ -14,7 +14,7 @@
     "@de-re-crud/ui": "0.16.11"
   },
   "devDependencies": {
-    "@de-re-crud/ui": "^0.16.11",
+    "@de-re-crud/ui": "^0.16.12",
     "preact-testing-library": "^0.4.0"
   }
 }

--- a/packages/theme-bootstrap4/package.json
+++ b/packages/theme-bootstrap4/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/theme-bootstrap4",
   "description": "Bootstrap 4 theme for De Re CRUD interfaces",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/theme-bootstrap4",
   "license": "Apache-2.0",
   "main": "de-re-crud-theme-bootstrap4.umd.js",
@@ -11,10 +11,10 @@
     "build": "rollup --config"
   },
   "peerDependencies": {
-    "@de-re-crud/ui": "0.16.10"
+    "@de-re-crud/ui": "0.16.11"
   },
   "devDependencies": {
-    "@de-re-crud/ui": "^0.16.10",
+    "@de-re-crud/ui": "^0.16.11",
     "preact-testing-library": "^0.4.0"
   }
 }

--- a/packages/theme-bootstrap4/src/renderers/boolean-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/boolean-field-renderer.tsx
@@ -11,6 +11,7 @@ const Bootstrap4BooleanFieldRenderer = ({
   required,
   disabled,
   readOnly,
+  tabIndex,
 }: IBooleanFieldRenderer) => {
   const onManagedChange = (e: FieldChangeEvent) => {
     e.preventDefault();
@@ -30,6 +31,7 @@ const Bootstrap4BooleanFieldRenderer = ({
         checked={value}
         disabled={disabled}
         readOnly={readOnly}
+        tabIndex={tabIndex}
       />
       <Bootstrap4LabelRenderer
         htmlFor={rendererId}

--- a/packages/theme-bootstrap4/src/renderers/input-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/input-field-renderer.tsx
@@ -21,6 +21,7 @@ const Bootstrap4InputFieldRenderer = ({
   required,
   disabled,
   readOnly,
+  tabIndex,
   errors,
 }: Omit<ITextFieldRenderer, 'value'> &
   Omit<IIntegerFieldRenderer, 'value'> & { value?: string | number }) => {
@@ -59,6 +60,7 @@ const Bootstrap4InputFieldRenderer = ({
         required={required}
         disabled={disabled}
         readOnly={readOnly}
+        tabIndex={tabIndex}
         value={value}
       />
     </div>

--- a/packages/theme-bootstrap4/src/renderers/radio-list-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/radio-list-field-renderer.tsx
@@ -10,6 +10,7 @@ const Bootstrap4RadioListFieldRenderer = ({
   required,
   disabled,
   readOnly,
+  tabIndex,
   options,
 }: IRadioListFieldRenderer) => {
   const onManagedChange = (e: FieldChangeEvent) => {
@@ -41,6 +42,7 @@ const Bootstrap4RadioListFieldRenderer = ({
               checked={option.selected}
               disabled={disabled}
               readOnly={readOnly}
+              tabIndex={tabIndex}
             />
             <Bootstrap4LabelRenderer
               htmlFor={inputId}

--- a/packages/theme-bootstrap4/src/renderers/select-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/select-renderer.tsx
@@ -16,6 +16,7 @@ const Bootstrap4SelectRenderer = ({
   required,
   disabled,
   readOnly,
+  tabIndex,
 }: Bootstrap4SelectRendererProps) => (
   <div className="bootstrap4-select-renderer">
     <Bootstrap4LabelRenderer fieldRequired={required}>
@@ -30,9 +31,10 @@ const Bootstrap4SelectRenderer = ({
       onBlur={onBlur}
       onChange={onChange}
       multiple={multiSelect}
-      readOnly={readOnly}
       required={required}
       disabled={disabled}
+      readOnly={readOnly}
+      tabIndex={tabIndex}
     >
       {options.map((option) => (
         <option

--- a/packages/theme-bootstrap4/src/renderers/text-area-field-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/text-area-field-renderer.tsx
@@ -15,6 +15,7 @@ const Bootstrap4TextAreaFieldRenderer = ({
   required,
   disabled,
   readOnly,
+  tabIndex,
   errors,
 }: ITextAreaFieldRenderer) => {
   return (
@@ -34,6 +35,7 @@ const Bootstrap4TextAreaFieldRenderer = ({
         required={required}
         disabled={disabled}
         readOnly={readOnly}
+        tabIndex={tabIndex}
         value={value}
       />
     </div>

--- a/packages/ui-integration-tests/package.json
+++ b/packages/ui-integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/ui-integration-tests",
   "description": "Test suite for integration of De Re CRUD libraries",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/ui-integration-tests",
   "license": "Apache-2.0",
   "scripts": {
@@ -9,9 +9,9 @@
     "cover": "jest --coverage"
   },
   "devDependencies": {
-    "@de-re-crud/core": "^0.16.10",
-    "@de-re-crud/theme-bootstrap4": "^0.16.10",
-    "@de-re-crud/ui": "^0.16.10",
+    "@de-re-crud/core": "^0.16.11",
+    "@de-re-crud/theme-bootstrap4": "^0.16.11",
+    "@de-re-crud/ui": "^0.16.11",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/preact": "^1.0.2",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/ui-integration-tests/package.json
+++ b/packages/ui-integration-tests/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/ui-integration-tests",
   "description": "Test suite for integration of De Re CRUD libraries",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/ui-integration-tests",
   "license": "Apache-2.0",
   "scripts": {
@@ -9,9 +9,9 @@
     "cover": "jest --coverage"
   },
   "devDependencies": {
-    "@de-re-crud/core": "^0.16.11",
-    "@de-re-crud/theme-bootstrap4": "^0.16.11",
-    "@de-re-crud/ui": "^0.16.11",
+    "@de-re-crud/core": "^0.16.12",
+    "@de-re-crud/theme-bootstrap4": "^0.16.12",
+    "@de-re-crud/ui": "^0.16.12",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/preact": "^1.0.2",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/ui",
   "description": "Core library for creating De Re CRUD interfaces and services",
-  "version": "0.16.10",
+  "version": "0.16.11",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/ui",
   "license": "Apache-2.0",
   "main": "de-re-crud-ui.umd.js",
@@ -13,14 +13,14 @@
     "cover": "jest --coverage"
   },
   "peerDependencies": {
-    "@de-re-crud/core": "0.16.10",
+    "@de-re-crud/core": "0.16.11",
     "preact": "^10.0.0-rc.3"
   },
   "dependencies": {
     "redux-zero": "^5.1.0"
   },
   "devDependencies": {
-    "@de-re-crud/core": "^0.16.10",
+    "@de-re-crud/core": "^0.16.11",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/preact": "^1.0.2",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@de-re-crud/ui",
   "description": "Core library for creating De Re CRUD interfaces and services",
-  "version": "0.16.11",
+  "version": "0.16.12",
   "repository": "https://github.com/DeReCrud/de-re-crud/tree/master/packages/ui",
   "license": "Apache-2.0",
   "main": "de-re-crud-ui.umd.js",
@@ -20,7 +20,7 @@
     "redux-zero": "^5.1.0"
   },
   "devDependencies": {
-    "@de-re-crud/core": "^0.16.11",
+    "@de-re-crud/core": "^0.16.12",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/preact": "^1.0.2",
     "@testing-library/user-event": "^7.1.2",

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -63,6 +63,8 @@ class FieldHostRenderer extends BaseComponent<
       ...fieldReference.hints.custom,
     };
 
+    const readOnly = this.isReadOnly();
+
     const fieldProps: IFieldRenderer = {
       errors,
       fieldDescription: field.help,
@@ -77,7 +79,8 @@ class FieldHostRenderer extends BaseComponent<
       placeholder: field.placeholder,
       busy: this.isBusy(fieldPath),
       disabled: this.isDisabled(),
-      readOnly: this.isReadOnly(),
+      readOnly,
+      tabIndex: readOnly ? -1 : undefined,
       formId,
       rendererId,
       required: field.required,

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -112,6 +112,7 @@ class FieldHostRenderer extends BaseComponent<
       struct,
       fieldReference.field,
     );
+
     return field.hints.readOnly;
   };
 
@@ -143,14 +144,6 @@ class FieldHostRenderer extends BaseComponent<
     return false;
   };
 
-  private changeValue = (
-    fieldName: string,
-    fieldPath: string,
-    value: ScalarFieldValue | ScalarFieldValue[],
-  ) => {
-    this.props.changeValue(this.props.struct, fieldName, fieldPath, value);
-  };
-
   private onFocus = () => {
     const {
       struct,
@@ -158,6 +151,10 @@ class FieldHostRenderer extends BaseComponent<
       fieldReference: { field },
       fieldPath,
     } = this.props;
+
+    if (this.isReadOnly() || this.isDisabled()) {
+      return;
+    }
 
     focusField(struct, field, fieldPath);
   };
@@ -170,6 +167,10 @@ class FieldHostRenderer extends BaseComponent<
       fieldPath,
       parentPath,
     } = this.props;
+
+    if (this.isReadOnly() || this.isDisabled()) {
+      return;
+    }
 
     blurField(struct, field, fieldPath, parentPath);
   };
@@ -208,7 +209,11 @@ class FieldHostRenderer extends BaseComponent<
       fieldPath,
     } = this.props;
 
-    this.changeValue(field, fieldPath, value);
+    if (this.isReadOnly() || this.isDisabled()) {
+      return;
+    }
+
+    this.props.changeValue(this.props.struct, field, fieldPath, value);
   };
 
   private onAdd = (

--- a/packages/ui/src/renderers/index.ts
+++ b/packages/ui/src/renderers/index.ts
@@ -88,6 +88,7 @@ export interface IFieldRenderer extends IRenderer {
   required: boolean;
   busy: boolean;
   readOnly: boolean;
+  tabIndex: number | undefined;
   disabled: boolean;
   onFocus: (e: FieldFocusEvent) => void;
   onBlur: (e: FieldBlurEvent) => void;


### PR DESCRIPTION
This disables tabbing on read only fields so that they don't trigger things like validation by exposing a new `tabIndex` prop.