### PR TITLE
Add renderers for field description and errors

### DIFF
--- a/packages/theme-bootstrap4/src/index.ts
+++ b/packages/theme-bootstrap4/src/index.ts
@@ -2,6 +2,8 @@ import Bootstrap4BlockContainerRenderer from './renderers/block-container-render
 import Bootstrap4BooleanFieldRenderer from './renderers/boolean-field-renderer';
 import Bootstrap4ButtonRenderer from './renderers/button-renderer';
 import Bootstrap4FieldContainerRenderer from './renderers/field-container-renderer';
+import Bootstrap4FieldDescriptionRenderer from './renderers/field-description-renderer';
+import Bootstrap4FieldErrorsRenderer from './renderers/field-errors-renderer';
 import Bootstrap4InlineLinkedStructFieldRenderer from './renderers/inline-linked-struct-field-renderer';
 import Bootstrap4InputFieldRenderer from './renderers/input-field-renderer';
 import Bootstrap4MultiSelectListFieldRenderer from './renderers/multi-select-list-field-renderer';
@@ -19,6 +21,8 @@ export {
   Bootstrap4BooleanFieldRenderer,
   Bootstrap4ButtonRenderer,
   Bootstrap4FieldContainerRenderer,
+  Bootstrap4FieldDescriptionRenderer,
+  Bootstrap4FieldErrorsRenderer,
   Bootstrap4InlineLinkedStructFieldRenderer,
   Bootstrap4MultiSelectListFieldRenderer,
   Bootstrap4InputFieldRenderer,

--- a/packages/theme-bootstrap4/src/options.ts
+++ b/packages/theme-bootstrap4/src/options.ts
@@ -3,6 +3,8 @@ import Bootstrap4BlockContainerRenderer from './renderers/block-container-render
 import Bootstrap4BooleanFieldRenderer from './renderers/boolean-field-renderer';
 import Bootstrap4ButtonRenderer from './renderers/button-renderer';
 import Bootstrap4FieldContainerRenderer from './renderers/field-container-renderer';
+import Bootstrap4FieldDescriptionRenderer from './renderers/field-description-renderer';
+import Bootstrap4FieldErrorsRenderer from './renderers/field-errors-renderer';
 import Bootstrap4InlineLinkedStructFieldRenderer from './renderers/inline-linked-struct-field-renderer';
 import Bootstrap4InputFieldRenderer from './renderers/input-field-renderer';
 import Bootstrap4MultiSelectListFieldRenderer from './renderers/multi-select-list-field-renderer';
@@ -22,6 +24,8 @@ const Bootstrap4RendererOptions: IRendererOptions = {
     derivedField: Bootstrap4InputFieldRenderer,
     estimateField: Bootstrap4InputFieldRenderer,
     fieldContainer: Bootstrap4FieldContainerRenderer,
+    fieldDescription: Bootstrap4FieldDescriptionRenderer,
+    fieldErrors: Bootstrap4FieldErrorsRenderer,
     foreignKeyField: Bootstrap4SelectListFieldRenderer,
     inlineLinkedStructField: Bootstrap4InlineLinkedStructFieldRenderer,
     integerField: Bootstrap4InputFieldRenderer,

--- a/packages/theme-bootstrap4/src/renderers/field-container-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/field-container-renderer.tsx
@@ -1,9 +1,9 @@
 import { h, IFieldContainerRenderer, combineCssClasses } from '@de-re-crud/ui';
 
 const Bootstrap4FieldContainerRenderer = ({
-  fieldDescription,
-  errors,
   renderedField,
+  renderedDescription,
+  renderedErrors,
 }: IFieldContainerRenderer) => (
   <div
     className={combineCssClasses(
@@ -12,15 +12,8 @@ const Bootstrap4FieldContainerRenderer = ({
     )}
   >
     {renderedField}
-    {fieldDescription &&
-      !errors.length && (
-        <span className="form-text text-muted">{fieldDescription}</span>
-      )}
-    {errors.length ? (
-      <span data-testid="field-error" className="invalid-feedback d-block">
-        {errors[0]}
-      </span>
-    ) : null}
+    {renderedDescription}
+    {renderedErrors}
   </div>
 );
 

--- a/packages/theme-bootstrap4/src/renderers/field-description-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/field-description-renderer.tsx
@@ -1,0 +1,14 @@
+import { h, IFieldDescriptionRenderer } from '@de-re-crud/ui';
+
+const Bootstrap4FieldDescriptionRenderer = ({
+  hasErrors,
+  fieldDescription,
+}: IFieldDescriptionRenderer) => {
+  if (hasErrors) {
+    return null;
+  }
+
+  return <span className="form-text text-muted">{fieldDescription}</span>;
+};
+
+export default Bootstrap4FieldDescriptionRenderer;

--- a/packages/theme-bootstrap4/src/renderers/field-errors-renderer.tsx
+++ b/packages/theme-bootstrap4/src/renderers/field-errors-renderer.tsx
@@ -1,0 +1,11 @@
+import { h, IFieldErrorsRenderer } from '@de-re-crud/ui';
+
+const Bootstrap4FieldErrorsRenderer = ({ errors }: IFieldErrorsRenderer) => {
+  return (
+    <span data-testid="field-error" className="invalid-feedback d-block">
+      {errors[0]}
+    </span>
+  );
+};
+
+export default Bootstrap4FieldErrorsRenderer;

--- a/packages/ui/src/renderers/defintions.ts
+++ b/packages/ui/src/renderers/defintions.ts
@@ -20,6 +20,8 @@ import {
   IDateFieldRenderer,
   IEstimateFieldRenderer,
   IKeywordFieldRenderer,
+  IFieldErrorsRenderer,
+  IFieldDescriptionRenderer,
 } from '.';
 
 export interface IRendererDefinitions {
@@ -35,6 +37,12 @@ export interface IRendererDefinitions {
   fieldContainer:
     | FunctionalComponent<IFieldContainerRenderer>
     | ComponentConstructor<IFieldContainerRenderer>;
+  fieldDescription:
+    | FunctionalComponent<IFieldDescriptionRenderer>
+    | ComponentConstructor<IFieldDescriptionRenderer>;
+  fieldErrors:
+    | FunctionalComponent<IFieldErrorsRenderer>
+    | ComponentConstructor<IFieldErrorsRenderer>;
   textField:
     | FunctionalComponent<ITextFieldRenderer>
     | ComponentConstructor<ITextFieldRenderer>;

--- a/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
+++ b/packages/ui/src/renderers/hosts/field-host-renderer/field-host-renderer.component.tsx
@@ -85,6 +85,36 @@ class FieldHostRenderer extends BaseComponent<
       hints: customHints,
     };
 
+    let renderedDescription: h.JSX.Element;
+    let renderedErrors: h.JSX.Element;
+
+    if (field.help) {
+      const FieldDescriptionRenderer = renderers.fieldDescription;
+
+      renderedDescription = (
+        <FieldDescriptionRenderer
+          rendererId={rendererId}
+          formId={formId}
+          hints={customHints}
+          hasErrors={errors.length > 0}
+          fieldDescription={field.help}
+        />
+      );
+    }
+
+    if (errors.length) {
+      const FieldErrorsRenderer = renderers.fieldErrors;
+
+      renderedErrors = (
+        <FieldErrorsRenderer
+          rendererId={rendererId}
+          formId={formId}
+          hints={customHints}
+          errors={errors}
+        />
+      );
+    }
+
     const renderedField = this.renderField(fieldReference, fieldProps);
     const FieldContainerRenderer = renderers.fieldContainer;
 
@@ -95,8 +125,10 @@ class FieldHostRenderer extends BaseComponent<
         fieldName={fieldProps.fieldName}
         fieldDescription={fieldProps.fieldDescription}
         errors={fieldProps.errors}
-        renderedField={renderedField}
         hints={customHints}
+        renderedField={renderedField}
+        renderedDescription={renderedDescription}
+        renderedErrors={renderedErrors}
       />
     );
   }

--- a/packages/ui/src/renderers/index.ts
+++ b/packages/ui/src/renderers/index.ts
@@ -36,7 +36,18 @@ export interface IFieldContainerRenderer extends IRenderer {
   fieldName: string;
   fieldDescription?: string;
   errors: string[];
-  renderedField?: h.JSX.Element;
+  renderedField: h.JSX.Element;
+  renderedDescription?: h.JSX.Element;
+  renderedErrors?: h.JSX.Element;
+}
+
+export interface IFieldDescriptionRenderer extends IRenderer {
+  hasErrors: boolean;
+  fieldDescription: string;
+}
+
+export interface IFieldErrorsRenderer extends IRenderer {
+  errors: string[];
 }
 
 export interface IStampRenderer extends IRenderer {

--- a/packages/ui/src/renderers/utils/parse-renderer-options.ts
+++ b/packages/ui/src/renderers/utils/parse-renderer-options.ts
@@ -16,6 +16,8 @@ export default function parseRendererOptions(
     derivedField: NoopRenderer as any,
     estimateField: NoopRenderer as any,
     fieldContainer: NoopRenderer as any,
+    fieldDescription: NoopRenderer as any,
+    fieldErrors: NoopRenderer as any,
     foreignKeyField: NoopRenderer as any,
     inlineLinkedStructField: NoopRenderer as any,
     integerField: NoopRenderer as any,


### PR DESCRIPTION
This splits the description and error rendering into their own renderers for easier customization.